### PR TITLE
load YAML in tests with unsafe_load

### DIFF
--- a/test/tc_rubygems_basic.rb
+++ b/test/tc_rubygems_basic.rb
@@ -234,7 +234,7 @@ module Versionomy
       def test_yaml
         value_ = ::Versionomy.create([1, 9, 2, 'a', 2], :rubygems)
         str_ = ::YAML.dump(value_)
-        value2_ = ::YAML.load(str_)
+        value2_ = ::YAML.unsafe_load(str_)
         assert_equal(value_, value2_)
       end
 

--- a/test/tc_semver_basic.rb
+++ b/test/tc_semver_basic.rb
@@ -202,7 +202,7 @@ module Versionomy
       def test_yaml
         value_ = ::Versionomy.create([1, 9, 2, 'pre2'], :semver)
         str_ = ::YAML.dump(value_)
-        value2_ = ::YAML.load(str_)
+        value2_ = ::YAML.unsafe_load(str_)
         assert_equal(value_, value2_)
       end
 

--- a/test/tc_standard_misc.rb
+++ b/test/tc_standard_misc.rb
@@ -84,7 +84,7 @@ module Versionomy
       def test_yaml
         value_ = ::Versionomy.create(:major => 1, :minor => 9, :tiny => 2, :release_type => :alpha, :alpha_version => 4)
         str_ = ::YAML.dump(value_)
-        value2_ = ::YAML.load(str_)
+        value2_ = ::YAML.unsafe_load(str_)
         assert_equal(value_, value2_)
       end
 


### PR DESCRIPTION
Starting from ruby3.1, the psych library uses safe_load underneath load to read YAML. As Versionomy::Value is not in the whitelist of classes permitted to be loaded two tests fails with the error 

```
Psych::DisallowedClass: Tried to load unspecified class: Versionomy::Value
```

This change proposes to use `unsafe_load` as the YAML content to be loaded is well controlled.